### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GDAX/Bitstamp Arbitrage
-When the spread on the two exchanges is greater than some threshold, we buy BTC on the cheaper exchange and sell on the more expensive one. We don't want to have any exposure to BTC so we are never long/short BTC. In order to make sure that we don't have only one side filled, we place a limit buy order on the cheaper exchange and when that fills we immediately execute a market order on the other exchange.
+When the spread on the two exchanges is greater than some threshold, we buy BTC on the cheaper exchange and sell on the more expensive one. We don't want to have any exposure to BTC so we are never long/short BTC. In order to make sure that we don't have only one side filled, we place a limit buy order on one exchange (usually gdax because of its marker-taker fees) and when that fills we immediately execute a market order on the other exchange.
 
 ## Features
 - We want to have an equal amount of BTC and cash on both exchanges in order to take advantage of a big spread in one direction


### PR DESCRIPTION
Just to clarify, where we place the limit order isn't related to what exchange BTC is cheaper on. We place limit orders of GDAX just cause they have maker-taker fees and bitstamp does not.